### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ function timesTwo(arr) {
     var _r = [];
 
     for (var _i = 0; _i < _a.length; _i++)
-        _a[_i].push(_f(_a[_i], _i, _a));
+        _r.push(_f(_a[_i], _i, _a));
 
     return _r;
 }


### PR DESCRIPTION
Doesn't it have to be `_r.push` instead of `_a[_i].push`? The second one does not even run :P

Also, I am wondering if we could make it even faster by extracting the arr.length:
```js
function timesTwo(arr) {
    var _a = arr;
    var _l = _a.length;
    var _f = n => n * 2;
    var _r = [];

    for (var _i = 0; _i < _l; ++_i)
        _r.push(_f(_a[_i], _i, _a));

    return _r;
}
```

I am not sure about `++i` vs. `i++` in JavaScript. I am used to `++i` (faster) coming from a C background, but might be optimized in JS anyways.